### PR TITLE
Enable macOS builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,9 @@ sudo: required
 # Before anything else, get the latest versions of things
 before_script:
   - julia -e 'Pkg.clone("https://github.com/JuliaPackaging/BinaryProvider.jl")'
-  - julia -e 'Pkg.clone("https://github.com/JuliaPackaging/BinaryBuilder.jl"); Pkg.build()'
+  # Temporarily use fork until https://github.com/JuliaPackaging/BinaryBuilder.jl/pull/243/files has been merged
+  # - julia -e 'Pkg.clone("https://github.com/JuliaPackaging/BinaryBuilder.jl"); Pkg.build()'
+  - julia -e 'Pkg.clone("https://github.com/andreasnoack/BinaryBuilder.jl"); Pkg.build()'
 
 script:
   - julia build_tarballs.jl


### PR DESCRIPTION
Temporarily use fork of BinaryBuilder to avoid running out of memory on Travis