### PR TITLE
Build on FreeBSD

### DIFF
--- a/build_tarballs.jl
+++ b/build_tarballs.jl
@@ -49,7 +49,8 @@ platforms = [
 #    BinaryProvider.Linux(:armv7l, :musl, :eabihf),
     BinaryProvider.MacOS(:x86_64, :blank_libc, :blank_abi),
     BinaryProvider.Windows(:i686, :blank_libc, :blank_abi),
-    BinaryProvider.Windows(:x86_64, :blank_libc, :blank_abi)
+    BinaryProvider.Windows(:x86_64, :blank_libc, :blank_abi),
+    BinaryProvider.FreeBSD(:x86_64, :blank_libc, :blank_abi),
 ]
 
 # The products that we will ensure are always built


### PR DESCRIPTION
Any reason not to use `supported_platforms()` here? (This PR just adds FreeBSD, which seems to work fine.)